### PR TITLE
Standardize You.com API key env var to YDC_API_KEY

### DIFF
--- a/recipes/llama_api_providers/OctoAI_API_examples/LiveData.ipynb
+++ b/recipes/llama_api_providers/OctoAI_API_examples/LiveData.ipynb
@@ -89,8 +89,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "YOUCOM_API_KEY = getpass()\n",
-    "os.environ[\"YOUCOM_API_KEY\"] = YOUCOM_API_KEY"
+    "YDC_API_KEY = getpass()\n",
+    "os.environ[\"YDC_API_KEY\"] = YDC_API_KEY"
    ]
   },
   {
@@ -156,7 +156,7 @@
     "import requests\n",
     "\n",
     "query = \"Meta Connect\" # you can try other live data query about sports score, stock market and weather info \n",
-    "headers = {\"X-API-Key\": os.environ[\"YOUCOM_API_KEY\"]}\n",
+    "headers = {\"X-API-Key\": os.environ[\"YDC_API_KEY\"]}\n",
     "data = requests.get(\n",
     "    f\"https://api.ydc-index.io/search?query={query}\",\n",
     "    headers=headers,\n",

--- a/recipes/use_cases/LiveData.ipynb
+++ b/recipes/use_cases/LiveData.ipynb
@@ -90,8 +90,8 @@
    "outputs": [],
    "source": [
     "\n",
-    "YOUCOM_API_KEY = getpass()\n",
-    "os.environ[\"YOUCOM_API_KEY\"] = YOUCOM_API_KEY"
+    "YDC_API_KEY = getpass()\n",
+    "os.environ[\"YDC_API_KEY\"] = YDC_API_KEY"
    ]
   },
   {
@@ -140,7 +140,7 @@
     "import requests\n",
     "\n",
     "query = \"Meta Connect\" # you can try other live data query about sports score, stock market and weather info \n",
-    "headers = {\"X-API-Key\": os.environ[\"YOUCOM_API_KEY\"]}\n",
+    "headers = {\"X-API-Key\": os.environ[\"YDC_API_KEY\"]}\n",
     "data = requests.get(\n",
     "    f\"https://api.ydc-index.io/search?query={query}\",\n",
     "    headers=headers,\n",


### PR DESCRIPTION
## What

Renames the `YOUCOM_API_KEY` environment variable to `YDC_API_KEY` in the two LiveData tutorial notebooks:

- `recipes/use_cases/LiveData.ipynb`
- `recipes/llama_api_providers/OctoAI_API_examples/LiveData.ipynb`

## Why

`YDC_API_KEY` is You.com's canonical API key environment variable, used by You.com's own docs/SDK and the LangChain/CrewAI/DSPy integrations. We are migrating ecosystem mentions of `YOUCOM_API_KEY` to `YDC_API_KEY`.

These are self-contained tutorial notebooks (not a library that others import), so a straight token rename is appropriate — no fallback needed. Notebook JSON was validated to still parse after the edit.

Part of a cross-ecosystem standardization effort: youdotcom-oss/integration-tracking#30